### PR TITLE
Make drawbacks and alternatives mandatory

### DIFF
--- a/enhancements/enhancement-template.md
+++ b/enhancements/enhancement-template.md
@@ -204,11 +204,11 @@ enhancement:
 Major milestones in the life cycle of a proposal should be tracked in `Implementation
 History`.
 
-## Drawbacks [optional]
+## Drawbacks
 
-Why should this enhancement _not_ be implemented.
+The idea is to find the best form of an argument why this enhancement should _not_ be implemented.
 
-## Alternatives [optional]
+## Alternatives
 
 Similar to the `Drawbacks` section the `Alternatives` section is used to
 highlight and record other possible approaches to delivering the value proposed


### PR DESCRIPTION
The drawbacks and alternatives sections invite honestly considered opposing arguments and serve to steel-man the proposal. I suggest these sections become mandatory in order to raise the quality standard for proposals.